### PR TITLE
fix: commitizen tag starts with "v"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
       - id: git-check
         files: "CHANGELOG.md"
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: 3.5.3
+    rev: v3.5.3
     hooks:
       - id: commitizen
         name: Lint commit message


### PR DESCRIPTION
The `commitizen` revision had a typo. It should be `v3.5.3` instead of `3.5.5`